### PR TITLE
Fixed issue when adding "constructor" as a key

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ FullTextSearchLight.prototype.init = function () {
 
     // Create indexes
     for (var i = 0; i < this.config.index_amount; i++) {
-        this.indexes.push({});
+        this.indexes.push(Object.create(null));
     }
 };
 


### PR DESCRIPTION
It will fail at line 180:if (this.indexes[i][parts[j]].indexOf(index) === -1)
because this.indexes[i][parts[j]] is not defined, but this.indexes[i]["constructor"] exists.
